### PR TITLE
[android_intent_plus] Add documentation for canResolveActivity

### DIFF
--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -70,4 +70,25 @@ of integers or strings.
 | :-----: |
 |   ✔️    |
 
+## Android 11 package visibility
+
+Android 11 introduced new permissions for package visibility.
+If you plan to use `canResolveActivity()` method, you need to specify queries in `AndroidManifest.xml` with specific package names:
+
+https://developer.android.com/training/package-visibility/declaring
+
+you can read more about package visibility on Android on Android Developers blog:
+
+https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9
+
+or Official Documentation
+
+https://developer.android.com/training/package-visibility
+
+please note that some packages are visible automatically and you don't have to specify queries:
+
+https://developer.android.com/training/package-visibility/automatic
+
+## Learn more
+
 Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)


### PR DESCRIPTION
Documents usage  of `canResolveActivity()` for Andorid 11 and up. With links to official documentation

Fixes: https://github.com/fluttercommunity/plus_plugins/issues/850

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.*

*e.g.*
- *Fix #123*
- *Related #456*

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

